### PR TITLE
add support for numeric fields in the filter

### DIFF
--- a/saiku-adhoc-core/src/main/java/org/saiku/adhoc/model/builder/CdaBuilder.java
+++ b/saiku-adhoc-core/src/main/java/org/saiku/adhoc/model/builder/CdaBuilder.java
@@ -192,6 +192,17 @@ public class CdaBuilder {
 			final String filterName = "F_" + param.getCategory() + "_" + param.getId();
 			String columnId = param.getCategory() + "." + param.getId();
 
+			if (param.getType().equals(DataType.NUMERIC.getName())) {
+				// numeric parameters
+				String formula = "OR(" + "IN([" + columnId + "]; [param:" + filterName + "]);" + "EQUALS(\"\"; [param:"
+						+ filterName + "]))";
+				Constraint cst = new Constraint(CombinationType.AND, formula);
+				query.getConstraints().add(cst);
+
+				Parameter paramMql = new Parameter(filterName, DataType.NUMERIC, "");
+				query.getParameters().add(paramMql);
+			}
+
 			if (param.getType().equals(DataType.STRING.getName())) {
 				// string parameters
 				String formula = "OR(" + "IN([" + columnId + "]; [param:" + filterName + "]);" + "EQUALS(\"\"; [param:"
@@ -270,6 +281,16 @@ public class CdaBuilder {
 				parameters.add(paramCdaFrom);
 				parameters.add(paramCdaTo);
 
+			} else if (column.getDataType().getName().equals("Numeric")) {
+				
+				String type = "Numeric";
+				String pattern = "";
+				type = pt.webdetails.cda.dataaccess.Parameter.Type.NUMERIC_ARRAY.getName();
+				pt.webdetails.cda.dataaccess.Parameter paramCda = new pt.webdetails.cda.dataaccess.Parameter(filterName,
+						type, "", pattern, pt.webdetails.cda.dataaccess.Parameter.Access.PUBLIC.name());
+
+				parameters.add(paramCda);
+			
 			}
 
 		}

--- a/saiku-adhoc-core/src/main/java/org/saiku/adhoc/service/report/ReportGeneratorService.java
+++ b/saiku-adhoc-core/src/main/java/org/saiku/adhoc/service/report/ReportGeneratorService.java
@@ -371,6 +371,24 @@ public class ReportGeneratorService {
 				paramDef.addParameterDefinition(plainParameterTo);
 
 			}
+			
+			if(saikuParameter.getType().equals("Numeric")){
+				final DefaultListParameter listParam = 
+					new DefaultListParameter(categoryId + "." + columnId, columnId, columnId, 
+							parameterName, true, false, Object[].class);
+				listParam.setParameterAttribute(
+						ParameterAttributeNames.Core.NAMESPACE, 
+						ParameterAttributeNames.Core.TYPE,
+						ParameterAttributeNames.Core.TYPE_LIST);
+				listParam.setParameterAttribute(
+						ParameterAttributeNames.Core.NAMESPACE, 
+						ParameterAttributeNames.Core.LABEL,
+						saikuParameter.getName());
+				paramDef.addParameterDefinition(listParam);
+
+			}
+
+			
 		}
 
 		//set layout horizontal

--- a/saiku-adhoc-core/src/main/java/org/saiku/adhoc/utils/ParamUtils.java
+++ b/saiku-adhoc-core/src/main/java/org/saiku/adhoc/utils/ParamUtils.java
@@ -73,6 +73,19 @@ public class ParamUtils {
 				}
 
 			}
+			
+			if (saikuParameter.getType().equals("Numeric")) {
+				List<String> valueList = saikuParameter.getParameterValues();
+				Double[] values = new Double[valueList.size()];
+				int i = 0;
+				for (String myInt : valueList) 
+	            {
+	            	values[i] = Double.valueOf(myInt);
+	            	i++;
+	            }
+				reportParameters.put(parameterName, values);
+			}
+
 
 		}
 		return reportParameters;


### PR DESCRIPTION
I have added the support for numeric fields in the filter.
So it is the same behaviour than for string fields, ie numeric values are displayed in the list of "Available values" and you can add them in the "Selected values".
